### PR TITLE
overwrite bootstrap in css classes

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 body {
-  background:grey;
+  background:grey !important;
 }
 .cal {
   width:100%;
@@ -48,7 +48,7 @@ body {
   margin: 15% auto; /* 15% from the top and centered */
   padding: 20px;
   border: 1px solid #888;
-  width: 80%; /* Could be more or less, depending on screen size */
+  width: 80% !important; /* Could be more or less, depending on screen size */
 }
 
 /* The Close Button */


### PR DESCRIPTION
add two !important to overwrite bootstrap variables. Not clean but works for now if bootstrap comes in the app.